### PR TITLE
Replace 404 custom var with injecting path into html (#11)

### DIFF
--- a/WSC.js
+++ b/WSC.js
@@ -40,15 +40,13 @@ _.extend(BaseHandler.prototype, {
                 this.fs.getByPath(this.app.opts['optCustom'+httpCode+'location'], (file) => {
                     if (! file.error && file.isFile) {
                         file.file(function(data) {
-                            if (httpCode == 404) {
-                                if (this.app.opts.optCustom404usevar) {
-                                    if (this.app.opts.optCustom404usevarvar.replace(' ', '') != '') {
-                                        var data = '<script>window.'+this.app.opts.optCustom404usevarvar+' = "'+this.request.uri+'";</script>\n' + data
-                                    } else {
-                                        this.write('javascript location variable is blank', 500)
-                                        this.finish()
-                                        return
-                                    }
+                            if (this.app.opts['optCustom' + httpCode + 'usevar']) {
+                                if (this.app.opts['optCustom' + httpCode + 'usevarvar'].replace(' ', '') != '') {
+                                    var data = data.replaceAll('{{' + this.app.opts['optCustom' + httpCode + 'usevarvar'] + '}}', this.request.origpath)
+                                } else {
+                                    this.write('javascript location variable is blank for ' + this.app.opts['optCustom' + httpCode + 'usevarvar'], 500)
+                                    this.finish()
+                                    return
                                 }
                             }
                             if (httpCode == 401) {

--- a/WSC.js
+++ b/WSC.js
@@ -42,7 +42,7 @@ _.extend(BaseHandler.prototype, {
                     if (! file.error && file.isFile) {
                         file.file(function(data) {
                             if (this.app.opts.optCustomusevar) {
-                                if (this.app.opts.optCustomusevarvar.replace(' ', '') != '') {
+                                if (this.app.opts.optCustomusevarvar.trim().length > 0) {
                                     var data = data.replaceAll(this.app.opts.optCustomusevarvar, this.request.origpath.htmlEscape())
                                 } else {
                                     this.write('Error Replace Variable is blank', 500)
@@ -2978,8 +2978,7 @@ function testHttpRequest() {
 }
 
 String.prototype.htmlEscape = function() {
-    var str = String(this)
-    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;")
+    return String(this).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;")
 }
 
 

--- a/WSC.js
+++ b/WSC.js
@@ -2881,7 +2881,7 @@ httpRequest.prototype = {
             request.reDirected = true
             request.headers = this.headers
             request.onload = this.onload
-            request.open(this.request.method, this.request.url)
+            request.open(this.request.method, res.headers.location)
             request.send(this.responseData || undefined)
             return
         }

--- a/howTo/post.md
+++ b/howTo/post.md
@@ -222,3 +222,7 @@ Will send a plain, static directory listing
 The `httpRequest` tool has been moved [here](httpRequest.md)
 
 
+
+Want to create a script compatible between this server and [Web Server For Chrome](https://github.com/ethanaobrien/web-server-chrome)?
+
+The `appInfo` variable will tell you which server you are using

--- a/howTo/post.md
+++ b/howTo/post.md
@@ -86,11 +86,11 @@ Example:
             var filetext = text // file.file will read the file as text. To render the file, you can use the renderFileContents() function
         })
     } else if (file.isDirectory) {
-		file.getDirContents(function(results) {
-			results[2].file(function(file) {
-				console.log(file)
-			})
-		}
+        file.getDirContents(function(results) {
+            results[2].file(function(file) {
+                console.log(file)
+            })
+        }
     }
 })
 ```
@@ -116,6 +116,7 @@ Call this to respond with no message. Dont forget to finish with `res.end()`
 
 `res.renderFileContents`: function
 Once you have called the file with `res.getFile()` (DO NOT use the `file.file()` function) use `res.renderFileContents()` to render the file
+DO NOT call `res.end()` when using this function
 Example:
 ```
 `res.getFile('../somefile.html', function(file) {
@@ -124,11 +125,11 @@ Example:
     } else if (file.isFile) {
         res.renderFileContents(file)
     } else if (file.isDirectory) {
-		file.getDirContents(function(results) {
-			results[2].file(function(file2) {
-				res.renderFileContents(file2)
-			})
-		}
+        file.getDirContents(function(results) {
+            results[2].file(function(file2) {
+                res.renderFileContents(file2)
+            })
+        }
     }
 })
 ```
@@ -192,7 +193,7 @@ Commands once you get the info:
 
 `entry.file(callback)`
 This function will read the file as text.
-If you want to display the contents of the file, it is recommended to use `res.renderFileContents`
+If you want to display the contents of the file, it is recommended to use `res.renderFileContents()`
 This function will only work on files, not directories
 
 `entry.getDirContents(callback)

--- a/howTo/post.md
+++ b/howTo/post.md
@@ -164,6 +164,8 @@ Example:
 console.log(req.body.toString())
 ```
 
+If you used the html form method, all the data will be avaliable under `req.bodyparams`
+
 
 `req.headers`: json string
 This contains all of the headers that the user sent when making the http request

--- a/package-lock.json
+++ b/package-lock.json
@@ -7227,6 +7227,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "net": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
+      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -8333,8 +8338,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -10001,7 +10005,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -10010,8 +10013,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2596,6 +2596,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -4007,6 +4017,36 @@
         "yargs": "^15.0.1"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true,
+          "optional": true
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -4015,8 +4055,77 @@
           "optional": true,
           "requires": {
             "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true,
+          "optional": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true,
+          "optional": true
         },
         "yargs": {
           "version": "15.4.1",
@@ -4025,13 +4134,28 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "cliui": "^6.0.0",
             "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
             "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
             "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
-            "which-module": "^2.0.0"
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -4073,8 +4197,28 @@
           "optional": true,
           "requires": {
             "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5079,6 +5223,13 @@
           "dev": true
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -6723,7 +6874,10 @@
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
       "integrity": "sha1-/u6mwTuhGYFKQ/xDxHCzHlnvcYo=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "nan": "^2.4.0"
+      }
     },
     "macos-release": {
       "version": "2.5.0",
@@ -7174,6 +7328,13 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -7226,11 +7387,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "net": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
-      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -8338,7 +8494,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -10005,6 +10162,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -10013,7 +10171,8 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
         }
       }
     },
@@ -10204,7 +10363,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "electron-squirrel-startup": "^1.0.0",
     "http": "^0.0.1-security",
     "https": "^1.0.0",
+    "net": "^1.0.2",
     "node-blob": "0.0.2",
     "send": "^0.17.1",
-    "underscore": "^1.9.1"
+    "underscore": "^1.9.1",
+    "url": "^0.11.0"
   },
   "config": {
     "forge": {

--- a/package.json
+++ b/package.json
@@ -26,11 +26,9 @@
     "electron-squirrel-startup": "^1.0.0",
     "http": "^0.0.1-security",
     "https": "^1.0.0",
-    "net": "^1.0.2",
     "node-blob": "0.0.2",
     "send": "^0.17.1",
-    "underscore": "^1.9.1",
-    "url": "^0.11.0"
+    "underscore": "^1.9.1"
   },
   "config": {
     "forge": {


### PR DESCRIPTION
Resolves #11 and a bug I found
```
optCustom400usevar
optCustom401usevar
optCustom403usevar
optCustom404usevar

optCustom400usevarvar
optCustom401usevarvar
optCustom403usevarvar
optCustom404usevarvar
```

For example, if the user has the variable set to `PATH`, the server will replace all `{{PATH}}` with the request path

For another example, if the user has the variable set to `locationoflostuser`, the server will replace all `{{locationoflostuser}}` with the request path

This is ready to merge